### PR TITLE
Fixing casing in recent readme patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Vue.use(VueStringFilter)
 <span>{{ stringWillFormatted | remove_first('stringToRemove') }}</span>
 <span>{{ stringWillFormatted | replace('stringToReplace') }}</span>
 <span>{{ stringWillFormatted | replace_first('stringToReplace') }}</span>
-<span>{{ stringWillFormatted | append('StringToAppend') }}</span>
+<span>{{ stringWillFormatted | append('stringToAppend') }}</span>
 ```
 
 ## Contributing


### PR DESCRIPTION
I noticed that all the casings in a recent patch were all camel case except for `append`, which was pascal case. This PR updates that so that all the casings are camel case.  